### PR TITLE
avoid ruamel_yaml versions that can't decode Unicode on UCS-2 Pythons

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,8 @@ requirements:
     - pycosat >=0.6.3
     - pyopenssl >=16.2.0
     - requests >=2.12.4,<3
-    - ruamel_yaml >=0.11.14
+    - ruamel_yaml >=0.11.14  # [py>27]
+    - ruamel_yaml >=0.11.14,<0.15.39|>=0.15.43  # [py<=27]
   run_constrained:
     - conda-build >=2.1
     - cytoolz >=0.8.1


### PR DESCRIPTION
Technically, it could be
```yaml
    - ruamel_yaml >=0.11.14  # [py>27]
    - ruamel_yaml >=0.11.14,<0.15.39|>=0.15.42  # [py<=27 and win]
    - ruamel_yaml >=0.11.14,<0.15.39|>=0.15.43  # [py<=27 and not win]
```
, but `>=0.11.14,<0.15.39|>=0.15.43  # [py<=27]` looks ugly enough already.