### PR TITLE
Moving cytoolz to be a run dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ requirements:
   run:
     - python
     - conda-package-handling >=1.3.0
+    - cytoolz >=0.8.1
     - menuinst >=1.4.11,<2         # [win]
     - pycosat >=0.6.3
     - pyopenssl >=16.2.0
@@ -53,7 +54,6 @@ requirements:
     - conda-build >=3
     - conda-content-trust >=0.1.1
     - conda-env >=2.6
-    - cytoolz >=0.8.1
 
 test:
 {% if run_upstream_tests == 'yes' %}


### PR DESCRIPTION
In the [conda](https://github.com/conda/conda) repository, we recently removed our vendor-ed version of toolz and added cytoolz as a dependency. This also need to be reflected in the feed stock, hence this pull request.

Link to pull request for the removal of the vendor-ed version of toolz (an addition of cytoolz)

- https://github.com/conda/conda/pull/11589

Related to this pull request: https://github.com/conda-forge/conda-feedstock/pull/170