### PR TITLE
Bump version to 4.14.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda" %}
 {% set version = "4.14.0" %}
 {% set build_number = "0" %}
-{% set sha256 = "????" %}
+{% set sha256 = "9b9fa3e20a2bcdd30496fc886bdd28b102e3a87eb3cdb4659b0a7e4e9edd52a8" %}
 # Running the upstream test suite requires the inclusion of test files, which
 # balloons the size of the package and occasionally triggers false-positive
 # security warnings; values can be "yes" or "no".

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,21 +1,23 @@
-{% set version = "4.13.0" %}
+{% set name = "conda" %}
+{% set version = "4.14.0" %}
+{% set build_number = "0" %}
+{% set sha256 = "????" %}
 # Running the upstream test suite requires the inclusion of test files, which
 # balloons the size of the package and occasionally triggers false-positive
 # security warnings; values can be "yes" or "no".
 {% set run_upstream_tests = "no" %}
 
 package:
-  name: conda
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: conda-{{ version }}.tar.gz
-  url: https://github.com/conda/conda/archive/{{ version }}.tar.gz
-  sha256: 30c4cee48ef3acc4e2d802c05baee44f5385f55b0c23c547b0961c51e1d140d2
+  url: https://github.com/conda/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
   skip: True  # [py<36]
-  number: 0
+  number: {{ build_number }}
   # These are present when the new environment is created
   # so we have to exempt them from the list of initial files
   # for conda-build to realize they should be included.


### PR DESCRIPTION
Bumps version for `conda 4.14.0` release.

Depends on #7 & #8