### PR TITLE
Rebuild to fix win-64 package on defaults

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda" %}
 {% set version = "22.11.1" %}
-{% set build_number = "3" %}
+{% set build_number = "4" %}
 {% set sha256 = "f9256a7e71a9f35063b683f6c7823acf05c1f75468fc609954f1f5efae7c03ac" %}
 # Running the upstream test suite requires the inclusion of test files, which
 # balloons the size of the package and occasionally triggers false-positive


### PR DESCRIPTION
The latest **win-64** `conda-22.11.1` (build num 3) package on defaults has a problem that was caused by how `git` is installed on our **new** build system (Prefect). Building the package on the **old** build system (Concourse) should resolve the problem for now.

Bumping the build number and rebuilding win-64 on Concourse (all other platforms will be rebuilt on Prefect).

Concourse pipeine: https://concourse.build.corp.continuum.io/teams/main/pipelines/pyim_conda-22.11.1-b4