### PR TITLE
Rebuild 22.11.1 for python 3.11

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+channels:
+  mesters_org: constructor
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-channels:
-  mesters_org: constructor
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "--error-overdepending"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda" %}
-{% set version = "23.1.0" %}
-{% set build_number = "0" %}
-{% set sha256 = "ba417f2e77806be36ab99a7640262b263a2dc809398d9403ea5f6f8f14dcc1a8" %}
+{% set version = "22.11.1" %}
+{% set build_number = "4" %}
+{% set sha256 = "f9256a7e71a9f35063b683f6c7823acf05c1f75468fc609954f1f5efae7c03ac" %}
 # Running the upstream test suite requires the inclusion of test files, which
 # balloons the size of the package and occasionally triggers false-positive
 # security warnings; values can be "yes" or "no".

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda" %}
 {% set version = "22.11.1" %}
-{% set build_number = "4" %}
+{% set build_number = "5" %}
 {% set sha256 = "f9256a7e71a9f35063b683f6c7823acf05c1f75468fc609954f1f5efae7c03ac" %}
 # Running the upstream test suite requires the inclusion of test files, which
 # balloons the size of the package and occasionally triggers false-positive


### PR DESCRIPTION
Required by [constructor](https://github.com/AnacondaRecipes/constructor-feedstock/pull/9)

Constructor requires `conda <23.1.0`. In order to build `constructor` for `python 3.11`, we need an earlier version of `conda` available on defaults.