### PR TITLE
Bump to v23.7.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda" %}
-{% set version = "23.7.2" %}
+{% set version = "23.7.3" %}
 {% set build_number = "0" %}
-{% set sha256 = "4fd44862ef87c73e4641b0c40a0873e103a097d6fd4a992041cfa9177ce20ac8" %}
+{% set sha256 = "c2c7c12a087b03e2d6833fe4d9b4898de0216721d19eb4ac8b573ff833378711" %}
 # Running the upstream test suite requires the inclusion of test files, which
 # balloons the size of the package and occasionally triggers false-positive
 # security warnings; values can be "yes" or "no".


### PR DESCRIPTION
Patch release to fix regression running executable subcommands installed into non-base environments.

Xref https://github.com/conda/conda/issues/12849

Changelog https://github.com/conda/conda/releases/tag/23.7.3