### PR TITLE
Bump to 23.11.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,26 +43,26 @@ requirements:
     - hatch-vcs >=0.2.0
     - wheel
     # for `conda init` in build/script above
+    - menuinst >=1.4.11,<2         # [win]
     - requests >=2.27.0,<3
     - ruamel.yaml >=0.11.14,<0.18
     - tqdm >=4
-    - menuinst >=1.4.11,<2         # [win]
   run:
-    - python
+    - archspec
+    - boltons >=23.0.0
+    - conda-libmamba-solver >=23.11.0
     - conda-package-handling >=2.2.0
+    - jsonpatch >=1.32
     - menuinst >=1.4.11,<2         # [win]
     - packaging >=23.0
+    - pluggy >=1.0.0
     - pycosat >=0.6.3
+    - python
     - requests >=2.27.0,<3
     - ruamel.yaml >=0.11.14,<0.18
     - setuptools >=60.0.0
-    - pluggy >=1.0.0
     - tqdm >=4
-    - boltons >=23.0.0
-    - jsonpatch >=1.32
     - truststore >=0.8.0           # [py>=310]
-    - archspec
-    - conda-libmamba-solver >=23.11.0
   run_constrained:
     - conda-build >=3.18.3
     - conda-content-trust >=0.1.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,6 @@ requirements:
     - menuinst >=1.4.11,<2         # [win]
     - packaging >=23.0
     - pycosat >=0.6.3
-    - pyopenssl >=16.2.0
     - requests >=2.27.0,<3
     - ruamel.yaml >=0.11.14,<0.18
     - setuptools >=60.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda" %}
-{% set version = "23.10.0" %}
+{% set version = "23.11.0" %}
 {% set build_number = "0" %}
-{% set sha256 = "358692c92fb97eccefca1114c3f17e3bf5c3b419f602cbeda604cfdfc469791a" %}
+{% set sha256 = "74f24daabb4642dcb36a97013fb753bb7ba99c112724b48e2b59d60294012da6" %}
 # Running the upstream test suite requires the inclusion of test files, which
 # balloons the size of the package and occasionally triggers false-positive
 # security warnings; values can be "yes" or "no".
@@ -43,28 +43,31 @@ requirements:
     - hatch-vcs >=0.2.0
     - wheel
     # for `conda init` in build/script above
-    - menuinst >=1.4.11,<2         # [win]
-    - requests >=2.27.0,<3
-    - ruamel.yaml >=0.11.14,<0.18
+    - menuinst >=2
+    - requests >=2.28.0,<3
+    - ruamel.yaml >=0.11.14,<0.19
     - tqdm >=4
   run:
     - archspec
     - boltons >=23.0.0
+    - charset-normalizer
     - conda-libmamba-solver >=23.11.0
     - conda-package-handling >=2.2.0
+    - distro >=1.5.0
     - jsonpatch >=1.32
-    - menuinst >=1.4.11,<2         # [win]
+    - menuinst
     - packaging >=23.0
+    - platformdirs >=3.10.0
     - pluggy >=1.0.0
     - pycosat >=0.6.3
     - python
-    - requests >=2.27.0,<3
-    - ruamel.yaml >=0.11.14,<0.18
+    - requests >=2.28.0,<3
+    - ruamel.yaml >=0.11.14,<0.19
     - setuptools >=60.0.0
     - tqdm >=4
     - truststore >=0.8.0           # [py>=310]
   run_constrained:
-    - conda-build >=3.18.3
+    - conda-build >=3.27
     - conda-content-trust >=0.1.1
     - conda-env >=2.6
 


### PR DESCRIPTION
- Removes unnecessary dependency (pyopenssl), see https://github.com/conda/conda/pull/13170
- Sorts dependencies to mirror conda and conda-forge's recipes for easier maintenance
- Bump to latest version and update dependencies