### PR TITLE
temporary with --no-test

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,7 @@
+aggregate_check: 3.12
+
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"
+  - "--no-test"


### PR DESCRIPTION
Building build number 0 with --no-test to circumvent the cyclic dependency on conda-libmamba-solver.