### PR TITLE
Bump to 24.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda" %}
-{% set version = "24.3.0" %}
+{% set version = "24.4.0" %}
 {% set build_number = "0" %}
-{% set sha256 = "017297e3a46193aeac2b7bcbb5064f394a968122b1c1c113c1b1fc1446270f0f" %}
+{% set sha256 = "8b67b076f7f48ff21c46aaf85c9c42eae5868a8ed910e4bdec946675d140397f" %}
 # Running the upstream test suite requires the inclusion of test files, which
 # balloons the size of the package and occasionally triggers false-positive
 # security warnings; values can be "yes" or "no".


### PR DESCRIPTION
conda 24.4.0

**Destination channel:** defaults

### Links

- https://anaconda.atlassian.net/browse/PKG-4611
- [Upstream repository](https://github.com/conda/conda)
- [Upstream changelog/diff](https://github.com/conda/conda/compare/24.3.0...24.4.0)
- Relevant dependency PRs:
  - https://github.com/conda/conda/releases/tag/24.4.0

### Explanation of changes:

- Shipping signed exe stubs
