### PR TITLE
Bump to 24.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda" %}
-{% set version = "24.4.0" %}
+{% set version = "24.5.0" %}
 {% set build_number = "0" %}
-{% set sha256 = "8b67b076f7f48ff21c46aaf85c9c42eae5868a8ed910e4bdec946675d140397f" %}
+{% set sha256 = "27b9203fbf88a831058cb0ee1e558600b7d9dab248eaa53011c21517296defb2" %}
 # Running the upstream test suite requires the inclusion of test files, which
 # balloons the size of the package and occasionally triggers false-positive
 # security warnings; values can be "yes" or "no".
@@ -41,13 +41,12 @@ requirements:
     - pip
     - hatchling >=1.12.2
     - hatch-vcs >=0.2.0
-    - wheel
     # for `conda init` in build/script above
+    - boltons >=23.0.0
     - menuinst >=2
     - requests >=2.28.0,<3
     - ruamel.yaml >=0.11.14,<0.19
     - tqdm >=4
-    - boltons >=23.0.0
   run:
     - archspec >=0.2.3
     - boltons >=23.0.0
@@ -55,6 +54,7 @@ requirements:
     - conda-libmamba-solver >=23.11.0
     - conda-package-handling >=2.2.0
     - distro >=1.5.0
+    - frozendict >=2.4.2
     - jsonpatch >=1.32
     - menuinst >=2
     - packaging >=23.0


### PR DESCRIPTION
conda 24.5.0

> [!WARNING]
> This is in draft mode and should not be merged until Monday, May 13th

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/conda/conda)
- [Upstream changelog/diff](https://github.com/conda/conda/releases/tag/24.5.0)
- Relevant dependency PRs:
  - https://github.com/conda/conda/issues/13870

### Explanation of changes:

- Remove `wheel` per https://github.com/conda/conda/pull/13684
- Add `frozendict` per https://github.com/conda/conda/pull/13766
