### PR TITLE
`conda 24.9.0` version bump

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda" %}
-{% set version = "24.7.1" %}
+{% set version = "24.9.0" %}
 {% set build_number = "0" %}
-{% set sha256 = "bba5ba84425a76b738a433511bfaf81420548b869429ef5c45019e526869e87b" %}
+{% set sha256 = "ed725eab2a8f3ac139b115c980d8858e24f042de05d924495ef0c9cd89188adc" %}
 # Running the upstream test suite requires the inclusion of test files, which
 # balloons the size of the package and occasionally triggers false-positive
 # security warnings; values can be "yes" or "no".
@@ -44,6 +44,7 @@ requirements:
     # for `conda init` in build/script above
     - boltons >=23.0.0
     - menuinst >=2
+    - platformdirs >=3.10.0
     - requests >=2.28.0,<3
     - ruamel.yaml >=0.11.14,<0.19
     - tqdm >=4


### PR DESCRIPTION
conda 24.9.0

**Destination channel:** defaults

### Links

- [PKG-5814](https://anaconda.atlassian.net/browse/PKG-5814)
- [Upstream repository](https://github.com/conda/conda)
- [Upstream changelog/diff](https://github.com/conda/conda/releases/tag/24.9.0)
- Relevant dependency PRs:
  - n/a

### Explanation of changes:

- ...


[PKG-5814]: https://anaconda.atlassian.net/browse/PKG-5814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ