### PR TITLE
conda 24.9.1 version bump

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda" %}
-{% set version = "24.9.0" %}
+{% set version = "24.9.1" %}
 {% set build_number = "0" %}
-{% set sha256 = "ed725eab2a8f3ac139b115c980d8858e24f042de05d924495ef0c9cd89188adc" %}
+{% set sha256 = "2d0d5d6db95ffee98f295900c2826ad66fbed5575a2bc025d094708822d70138" %}
 # Running the upstream test suite requires the inclusion of test files, which
 # balloons the size of the package and occasionally triggers false-positive
 # security warnings; values can be "yes" or "no".


### PR DESCRIPTION
conda 24.9.1

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/conda/conda)
- [Upstream changelog/diff](https://github.com/conda/conda/releases/tag/24.9.1)
- Relevant dependency PRs:
  - n/a

