### PR TITLE
Release conda 24.11.1.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda" %}
-{% set version = "24.11.0" %}
+{% set version = "24.11.1" %}
 {% set build_number = "0" %}
-{% set sha256 = "db49f3ead0efd8b2da95a5250860b653bc7216f2845367facdb5a4c51a541230" %}
+{% set sha256 = "4cb81345a497ced9be04f1230546b1dbde3aa3a3230600709835cd9426e245da" %}
 # Running the upstream test suite requires the inclusion of test files, which
 # balloons the size of the package and occasionally triggers false-positive
 # security warnings; values can be "yes" or "no".


### PR DESCRIPTION
conda 24.11.1

**Destination channel:** defaults

### Links

- [PKG-6508](https://anaconda.atlassian.net/browse/PKG-6508) 
- [Upstream repository](https://github.com/conda/conda)
- [Upstream changelog/diff](https://github.com/conda/conda/releases/tag/24.11.1)
- Relevant dependency PRs:
  - https://github.com/conda/conda/pull/14405

### Explanation of changes:

- Just a minor bugfix release for 24.11.x, fixing a regression with channel management.


[PKG-6508]: https://anaconda.atlassian.net/browse/PKG-6508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ