### PR TITLE
Isolated mode

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda" %}
 {% set version = "25.3.0" %}
-{% set build_number = "1" %}
+{% set build_number = "2" %}
 {% set sha256 = "8b55c2d420d5747f17cbe7088a4a216f02bc8f96fcbb1f2bbecc09095d455946" %}
 # Running the upstream test suite requires the inclusion of test files, which
 # balloons the size of the package and occasionally triggers false-positive

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,11 +14,12 @@ package:
 source:
   url: https://github.com/conda/{{ name }}/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  folder: conda-src
 
 build:
   skip: True  # [py<39]
   number: {{ build_number }}
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv && {{ PYTHON }} -I -m conda init --install
+  script: {{ PYTHON }} -m pip install conda-src/ --no-deps --no-build-isolation -vv && {{ PYTHON }} -m conda init --install
   # These are present when the new environment is created
   # so we have to exempt them from the list of initial files
   # for conda-build to realize they should be included.
@@ -78,8 +79,8 @@ requirements:
 test:
 {% if run_upstream_tests == 'yes' %}
   source_files:
-    - tests
-    - setup.cfg
+    - conda-src/tests
+    - conda-src/setup.cfg
 {% endif %}
   requires:
 {% if run_upstream_tests == 'yes' %}
@@ -102,7 +103,7 @@ about:
   home: https://docs.conda.io/
   license: BSD-3-Clause
   license_family: BSD
-  license_file: LICENSE
+  license_file: conda-src/LICENSE
   summary: OS-agnostic, system-level binary package and environment manager.
   description: |
     Conda is an open source package management system and environment

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
 build:
   skip: True  # [py<39]
   number: {{ build_number }}
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv && {{ PYTHON }} -m conda init --install
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv && {{ PYTHON }} -I -m conda init --install
   # These are present when the new environment is created
   # so we have to exempt them from the list of initial files
   # for conda-build to realize they should be included.


### PR DESCRIPTION
conda 25.3.0

**Destination channel:** defaults

### Links

- [PKG-7609](https://anaconda.atlassian.net/browse/PKG-7609) 
- [Upstream repository](https://github.com/conda/conda)
- ~Upstream changelog/diff~
- Relevant dependency PRs:
  - n/a

### Explanation of changes:

- https://github.com/conda/conda/issues/14694
- https://anaconda.slack.com/archives/C058SN1UBJ9/p1742913864257679
- Ensures the correct `conda` is invoked for `conda init`, i.e., use isolated mode to ensure we are invoking the installed package and not the source code

[PKG-7609]: https://anaconda.atlassian.net/browse/PKG-7609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ