### PR TITLE
Bump to 26.3.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda" %}
-{% set version = "26.3.1" %}
+{% set version = "26.3.2" %}
 {% set build_number = "0" %}
-{% set sha256 = "46319c5af2e0e0f94497af42655013bf757c5475ff2d2904c213850dcf71136b" %}
+{% set sha256 = "b5f5c1d4068a6582816d223733993eff354d55ec762ac555b49fdb8de07050c6" %}
 # Running the upstream test suite requires the inclusion of test files, which
 # balloons the size of the package and occasionally triggers false-positive
 # security warnings; values can be "yes" or "no".


### PR DESCRIPTION
conda 26.3.2

**Destination channel:** defaults

### Links

- [PKG-13558](https://anaconda.atlassian.net/browse/PKG-13558) 
- [Upstream repository](https://github.com/conda/conda)
- [Upstream changelog/diff](https://github.com/conda/conda/issues/15756)
- Relevant dependency PRs:
  - n/a

### Explanation of changes:

- Patch release to fix `conda run` regression


[PKG-13558]: https://anaconda.atlassian.net/browse/PKG-13558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ