### PR TITLE
Fix AttributeError for wrong pluggy minimum version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda" %}
 {% set version = "26.3.2" %}
-{% set build_number = "0" %}
+{% set build_number = "1" %}
 {% set sha256 = "b5f5c1d4068a6582816d223733993eff354d55ec762ac555b49fdb8de07050c6" %}
 # Running the upstream test suite requires the inclusion of test files, which
 # balloons the size of the package and occasionally triggers false-positive
@@ -62,7 +62,7 @@ requirements:
     - menuinst >=2
     - packaging >=23.0
     - platformdirs >=3.10.0
-    - pluggy >=1.0.0
+    - pluggy >=1.6.0
     - pycosat >=0.6.3
     - python
     - requests >=2.28.0,<3


### PR DESCRIPTION
conda 26.3.2 build 1

**Destination channel:** defaults

### Links

- [14330](https://anaconda.atlassian.net/browse/PKG-14330) 
- [Upstream repository](https://github.com/conda/conda)
- Upstream changelog/diff - N/A
- Relevant issues: https://github.com/conda/conda/issues/15862

### Explanation of changes:
- Fixes an AttributeError caused by the wrong minimum version of pluggy.
