### PR TITLE
Update to 26.5.0 and add bundled plugins

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda" %}
-{% set version = "26.3.2" %}
-{% set build_number = "1" %}
-{% set sha256 = "b5f5c1d4068a6582816d223733993eff354d55ec762ac555b49fdb8de07050c6" %}
+{% set version = "26.5.0" %}
+{% set build_number = "0" %}
+{% set sha256 = "b598ae17c44626eef4ad3cb3a295c5f35d5b0498dd978bf4a0c40d7f8209dfad" %}
 # Running the upstream test suite requires the inclusion of test files, which
 # balloons the size of the package and occasionally triggers false-positive
 # security warnings; values can be "yes" or "no".
@@ -54,7 +54,6 @@ requirements:
     - archspec >=0.2.3
     - boltons >=23.0.0
     - charset-normalizer
-    - conda-libmamba-solver >=25.11.0
     - conda-package-handling >=2.2.0
     - distro >=1.5.0
     - frozendict >=2.4.2
@@ -71,6 +70,11 @@ requirements:
     - tqdm >=4
     - truststore >=0.8.0           # [py>=310]
     - zstandard >=0.19.0
+    # Plugins to bundle with conda
+    - conda-libmamba-solver >=26.4.1
+    - conda-lockfiles >=0.2.0
+    - conda-self >=0.2.0
+    - conda-pypi >=0.9.0
   run_constrained:
     - conda-build >=25.9
     - conda-content-trust >=0.3.0


### PR DESCRIPTION
conda 26.5.0

**Destination channel:** defaults

### Links

- [PKG-14837](https://anaconda.atlassian.net/browse/PKG-14837) 
- [Upstream repository](https://github.com/conda/conda)
- [Upstream changelog/diff]()
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- ...


[PKG-14837]: https://anaconda.atlassian.net/browse/PKG-14837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ