### PR TITLE
Add conda-rattler-solver as a dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda" %}
 {% set version = "26.5.0" %}
-{% set build_number = "1" %}
+{% set build_number = "2" %}
 {% set sha256 = "1bb6bf13ea89a7736c0d35adedf8423b108ff3bbfbda35f850838b9d70570bfb" %}
 # Running the upstream test suite requires the inclusion of test files, which
 # balloons the size of the package and occasionally triggers false-positive
@@ -75,6 +75,7 @@ requirements:
     - conda-lockfiles >=0.2.0
     - conda-self >=0.2.0
     - conda-pypi >=0.9.0
+    - conda-rattler-solver >=0.1.0
   run_constrained:
     - conda-build >=25.9
     - conda-content-trust >=0.3.0


### PR DESCRIPTION
conda 26.5.0 build 2

**Destination channel:** defaults

### Links

- [PKG-14845](https://anaconda.atlassian.net/browse/PKG-14845) 
- [Upstream repository](https://github.com/conda/conda)
- [Upstream changelog/diff](): N/A
- Relevant dependency PRs: N/A

### Explanation of changes:

- Add conda-rattler-solver as a dependency


[PKG-14845]: https://anaconda.atlassian.net/browse/PKG-14845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ