### PR TITLE
Update to 26.5.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda" %}
-{% set version = "26.5.2" %}
+{% set version = "26.5.3" %}
 {% set build_number = "0" %}
-{% set sha256 = "4c0227d37f7a54b332fea5b12ba855252ca80fbc1452bb66522eb74084039be5" %}
+{% set sha256 = "473f8e8366bba2b4672cc5e350b66604f253541f11c40218a1a1a859527c3592" %}
 # Running the upstream test suite requires the inclusion of test files, which
 # balloons the size of the package and occasionally triggers false-positive
 # security warnings; values can be "yes" or "no".


### PR DESCRIPTION
conda 26.5.3

**Destination channel:** defaults

### Links

- [PKG-15595](https://anaconda.atlassian.net/browse/PKG-15595) 
- [Upstream repository](https://github.com/conda/conda)
- [Upstream changelog/diff](https://github.com/conda/conda/blob/26.5.x/CHANGELOG.md)
- Relevant dependency PRs: None

### Explanation of changes:

- Fixes 404 caused by shards caching on non-sharded channels
- Fixes a menuinst integration test


[PKG-15595]: https://anaconda.atlassian.net/browse/PKG-15595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ